### PR TITLE
Adicionar tomador CNPJ

### DIFF
--- a/src/main/java/br/com/flexait/nfse/builder/TomadorBuilder.java
+++ b/src/main/java/br/com/flexait/nfse/builder/TomadorBuilder.java
@@ -46,4 +46,12 @@ public class TomadorBuilder {
 		return this;
 	}
 	
+	public TomadorBuilder withCnpj(String string) {
+		LOG.debug("Pretador: {}", string);
+		
+		tomador.getIdentificacaoTomador().getCpfCnpj().setCnpj(string);
+		return this;
+	}
+	
+	
 }


### PR DESCRIPTION
Para conseguir gerar a nota fiscal para empresa que paga mensalidade de aluno.